### PR TITLE
Centralize config and add DHCP fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,9 @@
       \-> /api/cal/record?slot=... (G1..G9,R1,R2,NMID,NSEL)
       \-> /api/cal/save | /api/cal/load | /api/cal/clear
   • /net        : set Wi‑Fi password for SSID "Tractor" and reboot
+    (tries DHCP for 10 s then uses static 192.168.4.10/24 via 192.168.4.1;
+     if still disconnected, hosts AP "TractorShift-XXYY" with password
+     "shift1234")
 
   Build: Arduino IDE (ESP32 board core), select LOLIN S2 mini (ESP32‑S2).
   Libraries: built‑in WiFi, WebServer; install "Modbus-ESP8266".


### PR DESCRIPTION
## Summary
- Group all hardware and Wi‑Fi configuration values at the top of `main.ino`
- Add DHCP timeout with static IP fallback before switching to access point mode
- Document network fallback behavior in README
- Make WiFi access-point SSID prefix and password static

## Testing
- `arduino-cli compile ./ --fqbn esp32:esp32:lolin_s2_mini` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68c3cf736edc832a8e56e638f73bc1c3