### PR TITLE
Fix apiCalLoad response string

### DIFF
--- a/main.ino
+++ b/main.ino
@@ -404,9 +404,7 @@ void apiCalSave(){ saveCal(); http.send(200, "text/plain", "Saved\n"); }
 void apiCalLoad(){
   bool ok = loadCal();
   logf("[CAL] %s", ok?"loaded":"empty");
-  http.send(200, "text/plain", ok ? "Loaded
-" : "No data
-");
+  http.send(200, "text/plain", ok ? "Loaded\n" : "No data\n");
 }
 
 void apiCalClear(){ clearCal(); http.send(200, "text/plain", "Cleared\n"); }


### PR DESCRIPTION
## Summary
- Correct API calibration load handler to use escaped newlines in HTTP responses.

## Testing
- `apt-get update >/tmp/apt-update.log && tail -n 20 /tmp/apt-update.log` (fails: 403 Forbidden)
- `g++ -x c++ -fsyntax-only main.ino` (fails: WiFi.h missing)


------
https://chatgpt.com/codex/tasks/task_e_68c3f3e32108832abd3e48cc03c09f67