### PR TITLE
Fix ring buffer declarations order

### DIFF
--- a/main.ino
+++ b/main.ino
@@ -461,17 +461,14 @@ void maintainWifi(){
 }
 
 // ---------------- Logging ring buffer ----------------
+struct LogEntry { uint32_t t; uint16_t code; };
+constexpr size_t LOG_SIZE=256; LogEntry logBuf[LOG_SIZE]; size_t logHead=0;
+
 void logGear(uint16_t g){
-  extern LogEntry logBuf[];
-  extern size_t logHead;
   logBuf[logHead].t = millis();
   logBuf[logHead].code = g;
   logHead = (logHead+1) % LOG_SIZE;
 }
-
-// Ring buffer storage
-struct LogEntry { uint32_t t; uint16_t code; };
-constexpr size_t LOG_SIZE=256; LogEntry logBuf[LOG_SIZE]; size_t logHead=0;
 
 // heuristics
 inline bool magOK(uint16_t mag) { return (mag >= 1000 && mag <= 3500); }


### PR DESCRIPTION
## Summary
- define the log ring buffer types and storage before logGear to satisfy compilation
- simplify logGear now that declarations are in scope

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692ad17cbc30832aa0deaabb48f18a9c)